### PR TITLE
Replace venue info with the name of the workshop

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: workshop      # DON'T CHANGE THIS.
 carpentry: "academy"    # what kind of Carpentry (must be either "lc" or "dc" or "swc" or "academy").
                       # Be sure to update the Carpentry type in _config.yml as well.
-venue: "Netherlands eScience Center"        # brief name of host site without address (e.g., "Euphoric State University")
+venue: "Parallel programming in Python"        # brief name of host site without address (e.g., "Euphoric State University")
 address: "Science Park 140, Amsterdam"      # full street address of workshop (e.g., "Room A, 123 Forth Street, Blimingen, Euphoria")
 country: "Netherlands"      # lowercase two-letter ISO country code such as "fr" (see https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes)
 language: "en"     # lowercase two-letter ISO language code such as "fr" (see https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)


### PR DESCRIPTION
For non-Carpentries workshops, it makes more sense to put the name
of the course at the top instead of the venue. There is already eScience
Center logo at the top, so no need for repeating it.
